### PR TITLE
Adding testNG parallel execution example

### DIFF
--- a/selenium-pom-example/pom.xml
+++ b/selenium-pom-example/pom.xml
@@ -50,5 +50,11 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.14.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/selenium-pom-example/src/test/java/GoogleGuiceDependencyInjectionTestNGParallel.java
+++ b/selenium-pom-example/src/test/java/GoogleGuiceDependencyInjectionTestNGParallel.java
@@ -1,0 +1,67 @@
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import pages.google.Homepage;
+import pages.google.SearchResultsPage;
+import pages.google.sections.searchresults.SearchResult;
+import pages.wikipedia.Article;
+import uk.sponte.automation.seleniumpom.PageFactory;
+import uk.sponte.automation.seleniumpom.guice.DependencyInjectionConfiguration;
+import uk.sponte.automation.seleniumpom.guice.SeleniumPomGuiceParallelModule;
+
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Created by fecobar on 16/07/2018.
+ */
+public class GoogleGuiceDependencyInjectionTestNGParallel {
+    private PageFactory pageFactory;
+
+    @BeforeMethod
+    public void setupDependencyInjection() {
+        SeleniumPomGuiceParallelModule seleniumPomGuiceModule = new SeleniumPomGuiceParallelModule(new DependencyInjectionConfiguration());
+        seleniumPomGuiceModule.injectMembers(this);
+        pageFactory = seleniumPomGuiceModule.get(PageFactory.class);
+
+        pageFactory.get().getDriver().navigate().to("https://www.google.com/ncr");
+    }
+
+    @AfterMethod
+    public void teardown() {
+        pageFactory.get().getDriver().quit();
+    }
+
+    @Test(threadPoolSize = 2, invocationCount = 3)
+    public void runExampleTest() throws TimeoutException {
+        Homepage homepage = pageFactory.get(Homepage.class);
+
+        homepage.searchForm.searchFor("selenium");
+
+        SearchResultsPage searchResultsPage = pageFactory.get(SearchResultsPage.class);
+
+        searchResultsPage.resultStats.waitFor();
+
+        System.out.printf("Found %d results%n", searchResultsPage.searchResults.results.size());
+
+        Optional<SearchResult> potentialSearchResult = searchResultsPage
+                .searchResults
+                .results
+                .parallelStream()
+                .filter(result -> result.getUrl().getHost().equals("en.wikipedia.org"))
+                .findFirst();
+
+        if (!potentialSearchResult.isPresent())
+            throw new RuntimeException("Could not find a link with wikipedia in url");
+
+        SearchResult searchResult = potentialSearchResult.get();
+        String expectedSearchResultTitle = searchResult.title.getText();
+
+        searchResult.select();
+
+        Article article = pageFactory.get(Article.class);
+        article.firstHeading.waitFor();
+        Assert.assertEquals(pageFactory.get().getDriver().getTitle(), expectedSearchResultTitle);
+    }
+}

--- a/selenium-pom-guice/src/main/java/uk/sponte/automation/seleniumpom/guice/SeleniumPomGuiceParallelModule.java
+++ b/selenium-pom-guice/src/main/java/uk/sponte/automation/seleniumpom/guice/SeleniumPomGuiceParallelModule.java
@@ -1,0 +1,72 @@
+package uk.sponte.automation.seleniumpom.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.Stage;
+import com.google.inject.matcher.Matchers;
+import uk.sponte.automation.seleniumpom.PageFactory;
+import uk.sponte.automation.seleniumpom.dependencies.DependencyFactory;
+import uk.sponte.automation.seleniumpom.dependencies.DependencyInjector;
+import uk.sponte.automation.seleniumpom.dependencies.InjectionError;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+
+/**
+ * Created by fescobar on 16/07/18.
+ */
+public class SeleniumPomGuiceParallelModule extends AbstractModule
+        implements DependencyInjector {
+    private Injector injector;
+
+    private HashMap<Class, DependencyFactory> factories = new HashMap<Class, DependencyFactory>();
+    private PageFactory pageFactory;
+
+    private ArrayList<Module> modules = new ArrayList<Module>();
+
+    private static ThreadLocal<Injector> instances = new ThreadLocal<Injector>();
+
+    public SeleniumPomGuiceParallelModule(Module... modules) {
+        this.modules.add(this);
+        Collections.addAll(this.modules, modules);
+    }
+
+    @Override
+    protected void configure() {
+        // PageObjectModelTypeListener interrogates each type to see if it's a page object.
+        // It does this by looking at field types, if it's find any of PageElement,
+        bindListener(Matchers.any(), new PageObjectModelTypeListener());
+    }
+
+    @Provides
+    @Singleton
+    PageFactory providePageFactory() {
+        if (pageFactory != null) return pageFactory;
+
+        pageFactory = new PageFactory(this);
+        return pageFactory;
+    }
+
+    public Injector getInjector() {
+        if (this.injector == null) {
+            injector = Guice.createInjector(Stage.PRODUCTION, this.modules);
+            instances.set(injector);
+        }
+
+        return instances.get();
+    }
+
+    @Override
+    public <T> T get(Class<T> aClass) throws InjectionError {
+        return getInjector().getInstance(aClass);
+    }
+
+    public void injectMembers(Object object) {
+        getInjector().injectMembers(object);
+    }
+}


### PR DESCRIPTION
@sponte I've create a new class test named **GoogleGuiceDependencyInjectionTestNGParallel** using testNG. If you execute this test, it should open 3 browsers and pass successfully. I'm using another module that I've created too named **SeleniumPomGuiceParallelModule**. The only thing different that I added to this class is:

- **private static ThreadLocal<Injector> instances = new ThreadLocal<Injector>();**
- Change implementation of getInjector() method: 
```
    public Injector getInjector() {
        if (this.injector == null) {
            injector = Guice.createInjector(Stage.PRODUCTION, this.modules);
            instances.set(injector);
        }

        return instances.get();
    }
```
This is working from your project, but I think this class (SeleniumPomGuiceParallelModule) what I've created is not set up properly because when I tried to do the same from my project, including selenium-pom as a dependency, throw me an error:
```
Jul 16, 2018 4:24:17 P.M. com.google.inject.internal.MessageProcessor visit
INFO: An exception was caught and reported. Message: java.lang.IllegalStateException: zip file closed
java.lang.IllegalStateException: zip file closed
	at java.base/java.util.zip.ZipFile.ensureOpen(ZipFile.java:916)
	at java.base/java.util.zip.ZipFile.access$400(ZipFile.java:97)
	at java.base/java.util.zip.ZipFile$ZipEntryIterator.next(ZipFile.java:523)
	at java.base/java.util.zip.ZipFile$ZipEntryIterator.nextElement(ZipFile.java:516)
```
I think, I can't create injection dependencies concurrently. Do you know any way to do that properly? 




